### PR TITLE
#37 dumpコマンドで--configオプションのサポートを追加

### DIFF
--- a/bin/grab-deps.js
+++ b/bin/grab-deps.js
@@ -7,13 +7,33 @@ const [ , , subcommand ] = process.argv;
 switch ( subcommand ) {
 	case 'dump':
 		{
-			const dir = process.argv[ 3 ] || './src';
-			const json = process.argv[ 4 ] || './wp-dependencies.json';
-			const suffix = process.argv[ 5 ] || '';
-			const version = process.argv[ 6 ] || '0.0.0';
+			const args = process.argv.slice( 3 );
+			let dir = './src';
+			let json = './wp-dependencies.json';
+			let suffix = '';
+			let version = '0.0.0';
+			let configPath = null;
+
+			// Parse arguments
+			for ( let i = 0; i < args.length; i++ ) {
+				const arg = args[ i ];
+				if ( arg === '--config' ) {
+					configPath = args[ i + 1 ];
+					i++; // Skip next argument as it's the config path
+				} else if ( i === 0 ) {
+					dir = arg;
+				} else if ( i === 1 ) {
+					json = arg;
+				} else if ( i === 2 ) {
+					suffix = arg;
+				} else if ( i === 3 ) {
+					version = arg;
+				}
+			}
+
 			// eslint-disable-next-line no-console
 			console.log( `Scanning ${ dir } and dumping ${ json }` );
-			dumpSetting( dir, json, suffix, version );
+			dumpSetting( dir, json, suffix, version, configPath );
 		}
 		break;
 	case 'js':


### PR DESCRIPTION
## 概要

Issue #37の修正として、dumpコマンドで--configオプションのサポートを追加しました。

## 変更内容

### bin/grab-deps.js
- dumpコマンドの引数解析を改善
- --configオプションでカスタム設定ファイルを指定可能
- package.jsonのgrabDeps設定が正しく読み込まれるように修正

## 動作確認結果

### 1. 設定なしの場合（デフォルト動作）
- 通常のファイル名ベースのハンドル名が生成される
- 例：`test/src/js/components/list.js` → `"handle": "list"`

### 2. 設定ありの場合（grabDeps設定を追加）
- ディレクトリベースのハンドル名が正しく生成される
- 例：`test/src/js/components/list.js` → `"handle": "testlib-js-components-list"`
- 重複問題が解決される：
  - `test/src/js/modules/helper.js` → `"testlib-js-modules-helper"`
  - `test/src/js/utils/helper.js` → `"testlib-js-utils-helper"`

## 関連Issue

Closes #37